### PR TITLE
Add react 18 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
I added react 18 to the peer dependencies to avoid having to install the package with `--legacy-peer-deps`. I'm currently using it in a react 18 project and there are no issues.